### PR TITLE
[Bobbie] Scaffold VoiceInkService HTTP bridge

### DIFF
--- a/VoiceInkService/Package.resolved
+++ b/VoiceInkService/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/VoiceInkService/Package.swift
+++ b/VoiceInkService/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "VoiceInkService",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .executable(
+            name: "VoiceInkService",
+            targets: ["VoiceInkService"]),
+    ],
+    dependencies: [
+        // VoiceInkCore will be added as a local package dependency once extracted
+        // .package(path: "../VoiceInkCore"),
+
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "VoiceInkService",
+            dependencies: [
+                // .product(name: "VoiceInkCore", package: "VoiceInkCore"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/VoiceInkService"
+        ),
+    ]
+)

--- a/VoiceInkService/README.md
+++ b/VoiceInkService/README.md
@@ -1,0 +1,94 @@
+# VoiceInkService
+
+HTTP bridge service that wraps VoiceInkCore and exposes it as a local REST API.
+
+## Purpose
+
+VoiceInk.Windows (Avalonia C#) cannot import Swift packages directly. VoiceInkService runs as a sidecar process alongside the Windows app and provides all intelligence via HTTP on `127.0.0.1:7523`.
+
+## Architecture
+
+```
+VoiceInk.Windows (C# Avalonia)
+    ↓ HTTP :7523
+VoiceInkService (Swift executable)
+    ↓ Swift import
+VoiceInkCore (Swift Package)
+```
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /health | Health check |
+| GET | /models | List available transcription models |
+| POST | /transcribe | Transcribe audio (multipart/form-data) |
+| POST | /enhance | Enhance text with AI |
+| GET | /prompts | List all prompts |
+| POST | /prompts | Create custom prompt |
+| DELETE | /prompts/:id | Delete prompt |
+| GET | /settings | Get app settings |
+| PATCH | /settings | Update settings |
+
+### POST /transcribe
+
+Request: `multipart/form-data`
+- `audio`: binary audio data (WAV/PCM)
+- `modelId`: string
+
+Response:
+```json
+{ "text": "...", "duration": 2.3, "confidence": 0.95, "modelId": "whisper-tiny" }
+```
+
+### POST /enhance
+
+Request:
+```json
+{
+  "text": "...",
+  "promptId": "email",
+  "customPrompt": null,
+  "context": { "selectedText": "...", "activeUrl": "..." }
+}
+```
+
+Response:
+```json
+{ "enhancedText": "...", "model": "gpt-4o" }
+```
+
+## Running
+
+```bash
+# With real VoiceInkCore (after Naomi's PR is merged):
+swift run VoiceInkService --port 7523
+
+# With stub bridge (for development/testing without VoiceInkCore):
+swift run VoiceInkService --stub --port 7523
+
+# Custom host/port:
+swift run VoiceInkService --host 127.0.0.1 --port 8080
+```
+
+## Process Lifecycle
+
+VoiceInkService is started by VoiceInk.Windows on launch and killed on quit.
+It binds to `127.0.0.1` only — never accessible from outside the machine.
+Handles `SIGINT` and `SIGTERM` for clean shutdown.
+
+## HTTP Implementation
+
+The HTTP transport is currently scaffolded. Production implementation will use swift-nio or a similar library.
+
+To wire up swift-nio:
+1. Uncomment the `swift-nio` dependency in `Package.swift`
+2. Implement `HTTPServer.start()` using `ServerBootstrap`
+
+## VoiceInkCore Dependency
+
+VoiceInkCore is being developed separately (Naomi's `feature/voiceinkcore-package` branch).
+
+- `CoreBridgeProtocol` — abstract interface; keeps VoiceInkService compilable without VoiceInkCore
+- `StubCoreBridge` — full working stub for dev and testing
+- `VoiceInkCoreBridge` — real implementation; wire up once Naomi's PR merges by uncommenting `import VoiceInkCore` and the package dependency in `Package.swift`

--- a/VoiceInkService/Sources/VoiceInkService/CoreBridge/CoreBridgeProtocol.swift
+++ b/VoiceInkService/Sources/VoiceInkService/CoreBridge/CoreBridgeProtocol.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Abstract interface over VoiceInkCore — allows testing without the Swift Package dependency.
+/// In production, VoiceInkCoreBridge implements this using the real VoiceInkCore package.
+/// In testing/stub mode, StubCoreBridge provides predictable responses.
+public protocol CoreBridgeProtocol: AnyObject {
+    func health() async -> HealthResponse
+    func listModels() async -> [ModelInfoResponse]
+    func transcribe(audioData: Data, modelId: String) async throws -> TranscribeResponse
+    func enhance(request: EnhanceRequest) async throws -> EnhanceResponse
+    func listPrompts() async -> [PromptResponse]
+    func createPrompt(_ request: CreatePromptRequest) async throws -> PromptResponse
+    func deletePrompt(id: String) async throws
+    func getSettings() async -> SettingsResponse
+    func updateSettings(_ partial: [String: Any]) async throws
+}

--- a/VoiceInkService/Sources/VoiceInkService/CoreBridge/StubCoreBridge.swift
+++ b/VoiceInkService/Sources/VoiceInkService/CoreBridge/StubCoreBridge.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Stub implementation of CoreBridgeProtocol for testing and development.
+/// Returns predictable mock responses without requiring VoiceInkCore.
+public final class StubCoreBridge: CoreBridgeProtocol {
+
+    public init() {}
+
+    public func health() async -> HealthResponse {
+        HealthResponse(status: "ok (stub)", version: "1.0.0-stub")
+    }
+
+    public func listModels() async -> [ModelInfoResponse] {
+        [
+            ModelInfoResponse(id: "whisper-tiny", name: "Whisper Tiny", provider: "local", isLocal: true, isAvailable: true),
+            ModelInfoResponse(id: "whisper-base", name: "Whisper Base", provider: "local", isLocal: true, isAvailable: false),
+            ModelInfoResponse(id: "gpt-4o-audio", name: "GPT-4o Audio", provider: "openai", isLocal: false, isAvailable: false),
+        ]
+    }
+
+    public func transcribe(audioData: Data, modelId: String) async throws -> TranscribeResponse {
+        try await Task.sleep(nanoseconds: 500_000_000)
+        return TranscribeResponse(
+            text: "This is a stub transcription of \(audioData.count) bytes of audio.",
+            duration: 0.5,
+            confidence: 0.99,
+            modelId: modelId
+        )
+    }
+
+    public func enhance(request: EnhanceRequest) async throws -> EnhanceResponse {
+        try await Task.sleep(nanoseconds: 200_000_000)
+        return EnhanceResponse(
+            enhancedText: "[Enhanced] \(request.text)",
+            model: "stub-llm"
+        )
+    }
+
+    public func listPrompts() async -> [PromptResponse] {
+        [
+            PromptResponse(id: "general", title: "General", promptText: "Clean up this transcription.", icon: "✨", triggerWords: [], isBuiltIn: true),
+            PromptResponse(id: "email", title: "Email", promptText: "Format this as a professional email.", icon: "📧", triggerWords: ["email", "mail"], isBuiltIn: true),
+        ]
+    }
+
+    public func createPrompt(_ request: CreatePromptRequest) async throws -> PromptResponse {
+        PromptResponse(
+            id: UUID().uuidString,
+            title: request.title,
+            promptText: request.promptText,
+            icon: request.icon ?? "💬",
+            triggerWords: request.triggerWords ?? [],
+            isBuiltIn: false
+        )
+    }
+
+    public func deletePrompt(id: String) async throws {
+        // stub — do nothing
+    }
+
+    public func getSettings() async -> SettingsResponse {
+        SettingsResponse(
+            selectedTranscriptionModelId: "whisper-tiny",
+            selectedEnhancementModelId: nil,
+            isEnhancementEnabled: false,
+            defaultPromptId: "general",
+            ollamaBaseUrl: "http://localhost:11434"
+        )
+    }
+
+    public func updateSettings(_ partial: [String: Any]) async throws {
+        // stub — do nothing
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/CoreBridge/VoiceInkCoreBridge.swift
+++ b/VoiceInkService/Sources/VoiceInkService/CoreBridge/VoiceInkCoreBridge.swift
@@ -1,0 +1,62 @@
+import Foundation
+// import VoiceInkCore  // Uncomment when Naomi's PR is merged
+
+/// Production implementation of CoreBridgeProtocol using VoiceInkCore.
+/// This is where the real transcription, enhancement, and prompt management happen.
+public final class VoiceInkCoreBridge: CoreBridgeProtocol {
+
+    // TODO: Initialize VoiceInkCore services here
+    // private let transcriptionRegistry: TranscriptionServiceRegistry
+    // private let enhancementService: AIEnhancementService
+    // private let promptRegistry: PromptRegistry
+
+    public init() {
+        // TODO: Initialize when VoiceInkCore is available
+    }
+
+    public func health() async -> HealthResponse {
+        HealthResponse()
+    }
+
+    public func listModels() async -> [ModelInfoResponse] {
+        // TODO: Call VoiceInkCore.TranscriptionServiceRegistry.availableModels
+        return []
+    }
+
+    public func transcribe(audioData: Data, modelId: String) async throws -> TranscribeResponse {
+        // TODO: Call VoiceInkCore transcription pipeline
+        throw NSError(domain: "VoiceInkService", code: 501, userInfo: [NSLocalizedDescriptionKey: "Not yet implemented — VoiceInkCore not wired"])
+    }
+
+    public func enhance(request: EnhanceRequest) async throws -> EnhanceResponse {
+        // TODO: Call VoiceInkCore.AIEnhancementService
+        throw NSError(domain: "VoiceInkService", code: 501, userInfo: [NSLocalizedDescriptionKey: "Not yet implemented — VoiceInkCore not wired"])
+    }
+
+    public func listPrompts() async -> [PromptResponse] {
+        // TODO: Call VoiceInkCore.PromptRegistry
+        return []
+    }
+
+    public func createPrompt(_ request: CreatePromptRequest) async throws -> PromptResponse {
+        throw NSError(domain: "VoiceInkService", code: 501, userInfo: [NSLocalizedDescriptionKey: "Not yet implemented"])
+    }
+
+    public func deletePrompt(id: String) async throws {
+        throw NSError(domain: "VoiceInkService", code: 501, userInfo: [NSLocalizedDescriptionKey: "Not yet implemented"])
+    }
+
+    public func getSettings() async -> SettingsResponse {
+        SettingsResponse(
+            selectedTranscriptionModelId: nil,
+            selectedEnhancementModelId: nil,
+            isEnhancementEnabled: false,
+            defaultPromptId: nil,
+            ollamaBaseUrl: "http://localhost:11434"
+        )
+    }
+
+    public func updateSettings(_ partial: [String: Any]) async throws {
+        // TODO
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/HTTPServer.swift
+++ b/VoiceInkService/Sources/VoiceInkService/HTTPServer.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Minimal HTTP server scaffold.
+/// For production, replace with swift-nio or Vapor for proper HTTP transport.
+public final class HTTPServer {
+    private let host: String
+    private let port: Int
+    private let bridge: CoreBridgeProtocol
+    private let router: Router
+
+    public init(host: String, port: Int, bridge: CoreBridgeProtocol) {
+        self.host = host
+        self.port = port
+        self.bridge = bridge
+        self.router = Router(bridge: bridge)
+    }
+
+    public func start() throws {
+        print("🌐 VoiceInkService HTTP server starting on \(host):\(port)")
+        print("   Endpoints:")
+        print("   GET  /health")
+        print("   GET  /models")
+        print("   POST /transcribe")
+        print("   POST /enhance")
+        print("   GET  /prompts")
+        print("   POST /prompts")
+        print("   DELETE /prompts/:id")
+        print("   GET  /settings")
+        print("   PATCH /settings")
+        print("")
+        print("⚠️  HTTP server implementation is stubbed — use swift-nio for production")
+        print("   To add swift-nio: uncomment dependency in Package.swift")
+        print("")
+
+        Task {
+            await runHealthCheck()
+        }
+    }
+
+    private func runHealthCheck() async {
+        let health = await bridge.health()
+        print("✅ Bridge health check: \(health.status)")
+
+        let models = await bridge.listModels()
+        print("✅ Models available: \(models.count)")
+
+        let prompts = await bridge.listPrompts()
+        print("✅ Prompts available: \(prompts.count)")
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/EnhanceHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/EnhanceHandler.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct EnhanceHandler {
+    static func handle(request: EnhanceRequest, bridge: CoreBridgeProtocol) async throws -> EnhanceResponse {
+        try await bridge.enhance(request: request)
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/HealthHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/HealthHandler.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct HealthHandler {
+    static func handle(bridge: CoreBridgeProtocol) async -> HealthResponse {
+        await bridge.health()
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/ModelsHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/ModelsHandler.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct ModelsHandler {
+    static func handle(bridge: CoreBridgeProtocol) async -> [ModelInfoResponse] {
+        await bridge.listModels()
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/PromptsHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/PromptsHandler.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct PromptsHandler {
+    static func listPrompts(bridge: CoreBridgeProtocol) async -> [PromptResponse] {
+        await bridge.listPrompts()
+    }
+
+    static func createPrompt(_ request: CreatePromptRequest, bridge: CoreBridgeProtocol) async throws -> PromptResponse {
+        try await bridge.createPrompt(request)
+    }
+
+    static func deletePrompt(id: String, bridge: CoreBridgeProtocol) async throws {
+        try await bridge.deletePrompt(id: id)
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/SettingsHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/SettingsHandler.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct SettingsHandler {
+    static func getSettings(bridge: CoreBridgeProtocol) async -> SettingsResponse {
+        await bridge.getSettings()
+    }
+
+    static func updateSettings(_ partial: [String: Any], bridge: CoreBridgeProtocol) async throws {
+        try await bridge.updateSettings(partial)
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Handlers/TranscribeHandler.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Handlers/TranscribeHandler.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public struct TranscribeHandler {
+    /// Transcribe raw audio bytes using the specified model.
+    static func handle(audioData: Data, modelId: String, bridge: CoreBridgeProtocol) async throws -> TranscribeResponse {
+        try await bridge.transcribe(audioData: audioData, modelId: modelId)
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Models/APIModels.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Models/APIModels.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+// MARK: - Health
+
+public struct HealthResponse: Codable {
+    public let status: String
+    public let version: String
+
+    public init(status: String = "ok", version: String = "1.0.0") {
+        self.status = status
+        self.version = version
+    }
+}
+
+// MARK: - Models
+
+public struct ModelInfoResponse: Codable {
+    public let id: String
+    public let name: String
+    public let provider: String
+    public let isLocal: Bool
+    public let isAvailable: Bool
+}
+
+// MARK: - Transcription
+
+public struct TranscribeResponse: Codable {
+    public let text: String
+    public let duration: Double
+    public let confidence: Double
+    public let modelId: String
+}
+
+// MARK: - Enhancement
+
+public struct EnhanceRequest: Codable {
+    public let text: String
+    public let promptId: String?
+    public let customPrompt: String?
+    public let context: ContextInfo?
+
+    public struct ContextInfo: Codable {
+        public let selectedText: String?
+        public let activeUrl: String?
+        public let screenText: String?
+    }
+}
+
+public struct EnhanceResponse: Codable {
+    public let enhancedText: String
+    public let model: String
+}
+
+// MARK: - Prompts
+
+public struct PromptResponse: Codable {
+    public let id: String
+    public let title: String
+    public let promptText: String
+    public let icon: String
+    public let triggerWords: [String]
+    public let isBuiltIn: Bool
+}
+
+public struct CreatePromptRequest: Codable {
+    public let title: String
+    public let promptText: String
+    public let icon: String?
+    public let triggerWords: [String]?
+}
+
+// MARK: - Settings
+
+public struct SettingsResponse: Codable {
+    public let selectedTranscriptionModelId: String?
+    public let selectedEnhancementModelId: String?
+    public let isEnhancementEnabled: Bool
+    public let defaultPromptId: String?
+    public let ollamaBaseUrl: String
+}
+
+// MARK: - Error
+
+public struct ErrorResponse: Codable {
+    public let error: String
+    public let code: Int
+
+    public init(_ message: String, code: Int = 400) {
+        self.error = message
+        self.code = code
+    }
+}

--- a/VoiceInkService/Sources/VoiceInkService/Router.swift
+++ b/VoiceInkService/Sources/VoiceInkService/Router.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Route definitions for VoiceInkService.
+/// Maps HTTP method + path to handler functions.
+/// TODO: Implement with a real HTTP framework (swift-nio or Vapor)
+public final class Router {
+    let bridge: CoreBridgeProtocol
+
+    public init(bridge: CoreBridgeProtocol) {
+        self.bridge = bridge
+    }
+
+    // Route table — for documentation and future implementation
+    // GET  /health         → HealthHandler.handle
+    // GET  /models         → ModelsHandler.handle
+    // POST /transcribe     → TranscribeHandler.handle
+    // POST /enhance        → EnhanceHandler.handle
+    // GET  /prompts        → PromptsHandler.listPrompts
+    // POST /prompts        → PromptsHandler.createPrompt
+    // DELETE /prompts/:id  → PromptsHandler.deletePrompt
+    // GET  /settings       → SettingsHandler.getSettings
+    // PATCH /settings      → SettingsHandler.updateSettings
+}

--- a/VoiceInkService/Sources/VoiceInkService/main.swift
+++ b/VoiceInkService/Sources/VoiceInkService/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+import ArgumentParser
+
+// Note: file is named main.swift, so we call .main() at the bottom instead of using @main
+struct VoiceInkServiceCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "VoiceInkService",
+        abstract: "HTTP bridge service exposing VoiceInkCore to non-Swift shells",
+        version: "1.0.0"
+    )
+
+    @Option(name: .shortAndLong, help: "Port to listen on")
+    var port: Int = 7523
+
+    @Option(name: .long, help: "Host address to bind to")
+    var host: String = "127.0.0.1"
+
+    @Flag(name: .long, help: "Use stub bridge (for testing without VoiceInkCore)")
+    var stub: Bool = false
+
+    mutating func run() throws {
+        print("🎙 VoiceInkService starting on \(host):\(port)")
+
+        let bridge: CoreBridgeProtocol = stub
+            ? StubCoreBridge()
+            : VoiceInkCoreBridge()
+
+        let server = HTTPServer(host: host, port: port, bridge: bridge)
+
+        signal(SIGINT) { _ in
+            print("\n🛑 VoiceInkService shutting down...")
+            Darwin.exit(0)
+        }
+        signal(SIGTERM) { _ in Darwin.exit(0) }
+
+        try server.start()
+
+        RunLoop.main.run()
+    }
+}
+
+VoiceInkServiceCommand.main()


### PR DESCRIPTION
## Summary
Creates VoiceInkService — the Swift HTTP bridge between VoiceInkCore (Swift) and VoiceInk.Windows (C# Avalonia).

## Why this exists
Avalonia C# cannot import Swift packages directly. VoiceInkService solves this by running as a sidecar process alongside the Windows app, exposing all core operations over localhost HTTP.

## API Design
```
GET  /health
GET  /models
POST /transcribe    (multipart audio + modelId)
POST /enhance       (text + promptId + context)
GET  /prompts
POST /prompts
DELETE /prompts/:id
GET  /settings
PATCH /settings
```

## Architecture
```
VoiceInk.Windows (C#) → HTTP :7523 → VoiceInkService (this) → VoiceInkCore (Naomi's PR)
```

## What's complete
- Package.swift with swift-argument-parser CLI (--port, --host, --stub flags)
- Full Codable API models (all request/response types)
- CoreBridgeProtocol (abstract interface over VoiceInkCore)
- StubCoreBridge (full working stub for dev/testing)
- VoiceInkCoreBridge (wires to VoiceInkCore — TODOs until Naomi's PR merges)
- HTTPServer scaffold (architecture is correct, HTTP transport stubbed)
- `swift build` passes ✅
- Smoke test: `--stub` mode starts, bridge health check and model/prompt listing confirmed working

## Next steps
- Wire VoiceInkCoreBridge to real VoiceInkCore types (after Naomi's PR)
- Implement HTTPServer with swift-nio or Foundation HTTP server
- Add process lifecycle management (start on app launch, kill on quit)